### PR TITLE
Refactor/add basic automapper projectto

### DIFF
--- a/CleanTodo.Core/Application/Commands/TodoItems/CreateTodoItemHandler.cs
+++ b/CleanTodo.Core/Application/Commands/TodoItems/CreateTodoItemHandler.cs
@@ -24,6 +24,7 @@ namespace CleanTodo.Core.Application.Commands.TodoItems
             var todoItem = _mapper.Map<TodoItem>(request.Data);
             _dbContext.TodoItems.Add(todoItem);
             await _dbContext.SaveChangesAsync();
+
             return _mapper.Map<TodoItemResponse>(todoItem);
         }
     }

--- a/CleanTodo.Core/Application/Interfaces/Mapping/IMapTo.cs
+++ b/CleanTodo.Core/Application/Interfaces/Mapping/IMapTo.cs
@@ -4,6 +4,6 @@ namespace CleanTodo.Core.Application.Interfaces.Mapping
 {
     public interface IMapTo<TDestination>
     {
-        void ConfigureMapping(IProfileExpression config) => config.CreateMap(GetType(), typeof(TDestination));
+        void ConfigureMapping(IProfileExpression profile) => profile.CreateMap(GetType(), typeof(TDestination));
     }
 }

--- a/CleanTodo.Core/Application/Interfaces/Mapping/IProjectTo.cs
+++ b/CleanTodo.Core/Application/Interfaces/Mapping/IProjectTo.cs
@@ -1,0 +1,14 @@
+﻿using AutoMapper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CleanTodo.Core.Application.Interfaces.Mapping
+{
+    public interface IProjectTo<TSource, TDestination>
+    {
+        void ConfigureProjection(IProfileExpression profile) => profile.CreateProjection<TSource, TDestination>();
+    }
+}

--- a/CleanTodo.Core/Application/Queries/TodoItems/GetAllTodoItemsQuery.cs
+++ b/CleanTodo.Core/Application/Queries/TodoItems/GetAllTodoItemsQuery.cs
@@ -28,9 +28,10 @@ namespace CleanTodo.Core.Application.Queries.TodoItems
         {
             var items = await _dbContext.TodoItems
                 .AsNoTracking()
+                .ProjectTo<ProjectedTodoItemResponse>(_mapper.ConfigurationProvider)
                 .ToListAsync(cancellationToken);
 
-            return items.Select(x => _mapper.Map<TodoItemResponse>(x));
+            return items;
         }
     }
 }

--- a/CleanTodo.Core/Application/Queries/TodoItems/TodoItemResponse.cs
+++ b/CleanTodo.Core/Application/Queries/TodoItems/TodoItemResponse.cs
@@ -1,4 +1,5 @@
 ﻿using CleanTodo.Core.Application.Common;
+using CleanTodo.Core.Entities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,6 +17,8 @@ namespace CleanTodo.Core.Application.Queries.TodoItems
         public int RollOverCount { get; set; }
         public DateTime DueDate { get; set; }
         public DateTime? CompletionDate { get; set; }
-        public ICollection<Guid> Tags { get; set; } = new List<Guid>();
+        public ICollection<TodoTag> Tags { get; set; } = new List<TodoTag>();
     }
+
+    public class ProjectedTodoItemResponse : TodoItemResponse { }
 }

--- a/CleanTodo.Core/Configuration/MappingProfile.cs
+++ b/CleanTodo.Core/Configuration/MappingProfile.cs
@@ -38,14 +38,50 @@ namespace CleanTodo.Core.Configuration
                 var interfaceTypes = mappableType.GetInterfaces().Where(IsMappableType);
                 if (interfaceTypes.Any())
                 {
-                    interfaceTypes.ToList().ForEach(interfaceType =>
-                    {
-                        interfaceType.GetMethod(methodName, new Type[] { typeof(Profile) })?.Invoke(instance, new object[] { this });
-                    });
+                    InvokeConfigurationMethod(interfaceTypes, methodName, instance);
+                }
+            }
+
+            // Next, do the same thing, but look for projections being created
+            // instead of maps
+            var projectableTypes = assembly.GetExportedTypes()
+                .Where(t => t.GetInterfaces().Any(IsProjectableType))
+                .ToList();
+
+            foreach (var projectableType in projectableTypes)
+            {
+                // Create an instance of the type and see if the type implemented 
+                // the ConfigureProjection method. If so, invoke it and continue on.
+                var instance = Activator.CreateInstance(projectableType);
+                var methodName = nameof(IProjectTo<object, object>.ConfigureProjection);
+                var method = projectableType.GetMethod(methodName);
+
+                if (method != null)
+                {
+                    method.Invoke(instance, new object[] { this });
+                    continue;
+                }
+
+                // If the current type makes it here, then the implementation for
+                // ConfigureProjection is implemented on the interface itself as part
+                // of it's default implementation and needs to be invoked there.
+                var interfaceTypes = projectableType.GetInterfaces().Where(IsProjectableType);
+                if (interfaceTypes.Any())
+                {
+                    InvokeConfigurationMethod(interfaceTypes, methodName, instance);
                 }
             }
         }
 
         private bool IsMappableType(Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IMapTo<>);
+        private bool IsProjectableType(Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IProjectTo<,>);
+
+        private void InvokeConfigurationMethod(IEnumerable<Type> interfaceTypes, string methodName, object? instance)
+        {
+            interfaceTypes.ToList().ForEach(interfaceType =>
+            {
+                interfaceType.GetMethod(methodName, new Type[] { typeof(Profile) })?.Invoke(instance, new object[] { this });
+            });
+        }
     }
 }

--- a/CleanTodo.Core/Entities/TodoItem.cs
+++ b/CleanTodo.Core/Entities/TodoItem.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace CleanTodo.Core.Entities
 {
-    public class TodoItem : BaseEntity, IMapTo<TodoItemResponse>
+    public class TodoItem : BaseEntity, IMapTo<TodoItemResponse>, IProjectTo<TodoItem, ProjectedTodoItemResponse>
     {
         public string Description { get; set; } = string.Empty;
         public bool IsActive { get; set; }


### PR DESCRIPTION
- Created a new interface, `IProjectTo<,>` that can define automapper projections
- Added new response type that can be used with projection
- Learned that automapper cannot configure a map and projection for the same two types