### PR TITLE
Refactor/fix testing db deadlock

### DIFF
--- a/CleanTodo.IntegrationTests/TestWebApplicationFactory.cs
+++ b/CleanTodo.IntegrationTests/TestWebApplicationFactory.cs
@@ -3,14 +3,13 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Linq;
 
 namespace CleanTodo.IntegrationTests
 {
     public class TestWebApplicationFactory : WebApplicationFactory<Program>
     {
-        const string connectionString = @"Server=(localdb)\MSSQLLocalDB;Database=TodoTestDB;Trusted_Connection=true";
-
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.ConfigureServices(services =>
@@ -18,11 +17,19 @@ namespace CleanTodo.IntegrationTests
                 services.Remove(services.Single(s => s.ServiceType == typeof(DbContextOptions<TodoDbContext>)));
                 services.AddDbContext<TodoDbContext>(options =>
                 {
-                    options.UseSqlServer(connectionString);
+                    options.UseSqlServer(GetConnectionString());
                 });
             });
 
             base.ConfigureWebHost(builder);
+        }
+
+        private string GetConnectionString()
+        {
+            return string.Format(
+                @"Server=(localdb)\MSSQLLocalDB;Database=TodoTestDB_{0};Trusted_Connection=true",
+                Guid.NewGuid().ToString()
+            );
         }
     }
 }

--- a/CleanTodo.IntegrationTests/TestingBase.cs
+++ b/CleanTodo.IntegrationTests/TestingBase.cs
@@ -3,10 +3,6 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CleanTodo.IntegrationTests
 {

--- a/CleanTodo.IntegrationTests/TestingBase.cs
+++ b/CleanTodo.IntegrationTests/TestingBase.cs
@@ -1,5 +1,6 @@
 ﻿using CleanTodo.Infrastructure.Data;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -9,25 +10,33 @@ using System.Threading.Tasks;
 
 namespace CleanTodo.IntegrationTests
 {
-    abstract public class TestingBase
+    abstract public class TestingBase : IDisposable
     {
         private readonly TestWebApplicationFactory _factory;
         private readonly IServiceScope _serviceScope;
+        private TodoDbContext _dbContext;
         protected readonly IMediator _mediator;
+        
 
         public TestingBase()
         {
             _factory = new TestWebApplicationFactory();            
             _serviceScope = _factory.Services.GetRequiredService<IServiceScopeFactory>().CreateScope();            
             _mediator = _serviceScope.ServiceProvider.GetRequiredService<IMediator>();
+            _dbContext = _serviceScope.ServiceProvider.GetRequiredService<TodoDbContext>();
             InitalizeDatabase();
         }
 
         private void InitalizeDatabase()
         {
-            var db = _serviceScope.ServiceProvider.GetRequiredService<TodoDbContext>();
-            db.Database.EnsureDeleted();
-            db.Database.EnsureCreated();
+            _dbContext.Database.Migrate();
+        }
+
+        public void Dispose()
+        {
+            _dbContext.Database.EnsureDeleted();
+            _dbContext.Dispose();
+            GC.SuppressFinalize(this); // See CA1816
         }
     }
 }


### PR DESCRIPTION
- Fixed issue where DB was being deadlocked due to tests trying to use the same DB
- Changed connection string so each test gets a fresh DB for itself
- Modified `TestingBase` to get rid of the DB after the test has ran